### PR TITLE
[feat/1] 신규 유저 등록 및 조회 API

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,13 @@
 import http from 'http';
 import {Router} from './utils/Routes.js';
 import {ResponseHandler} from "./utils/ResponseHandler.js";
+import {userService} from "./services/UserService.js";
+import userRouter from "./routes/UserRoutes.js";
 
 export function createServer() {
     const router = new Router();
+
+    router.use(userRouter);
 
     const server = http.createServer(async (req, res) => {
         try {
@@ -20,14 +24,18 @@ export function createServer() {
     return server;
 }
 
-export function startServer(port = 3000) {
-    return new Promise((resolve, reject) => {
-        const server = createServer();
+export async function startServer(port = 3000) {
+    return new Promise(async (resolve, reject) => {
+        try {
+            await userService.initialize();
+            const server = createServer();
 
-        server.listen(port, () => {
-            resolve(server);
-        });
-
-        server.on('error', reject);
+            server.listen(port, () => {
+                resolve(server);
+            });
+            server.on('error', reject);
+        } catch (error) {
+            reject(error);
+        }
     });
 }

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -36,7 +36,7 @@ export class UserController {
 
     async findUserByEmail(req, res) {
         try {
-            const {email} = req.body;
+            const email = req.query.email;
 
             this.validateEmail(email);
 

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -31,6 +31,17 @@ export class UserController {
             ResponseHandler.error(res, error);
         }
     }
+
+    async findUserByEmail(req, res) {
+        try {
+            const {email} = req.body;
+
+            const user = await this.userService.findUserByEmail(email);
+            ResponseHandler.success(res, user, '사용자 정보를 성공적으로 가져왔습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error);
+        }
+    }
 }
 
-export const userController =  new UserController(userService);
+export const userController = new UserController(userService);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -1,5 +1,6 @@
 import {userService} from "../services/UserService.js";
 import {ResponseHandler} from "../utils/ResponseHandler.js";
+import {ValidationError} from "../utils/AppError.js";
 
 export class UserController {
 
@@ -11,9 +12,10 @@ export class UserController {
         try {
             const {email, name, birth} = req.body;
 
-            const newUser = await this.userService.createUser({
-                email, name, birth,
-            });
+            this.validateEmail(email);
+            this.validateName(name);
+
+            const newUser = await this.userService.createUser({email, name, birth,});
 
             ResponseHandler.success(res, '사용자가 정상적으로 등록되었습니다.', newUser);
         } catch (error) {
@@ -36,12 +38,35 @@ export class UserController {
         try {
             const {email} = req.body;
 
+            this.validateEmail(email);
+
             const user = await this.userService.findUserByEmail(email);
             ResponseHandler.success(res, '사용자 정보를 성공적으로 가져왔습니다.', user);
         } catch (error) {
             ResponseHandler.error(res, error);
         }
     }
+
+    validateEmail(email) {
+        if (!email || email.trim() === '') {
+            throw new ValidationError("이메일은 필수 입력 사항입니다.");
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            throw new ValidationError("올바른 이메일 형식이 아닙니다.");
+        }
+    }
+
+    validateName(name) {
+        if (!name || name.trim() === '') {
+            throw new ValidationError("이름은 필수 입력 사항입니다.");
+        }
+        if (name.length > 10) {
+            throw new ValidationError("이름은10글자 이내여야 합니다.");
+        }
+    }
+
 }
 
 export const userController = new UserController(userService);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -1,10 +1,26 @@
 import {userService} from "../services/UserService.js";
+import {ResponseHandler} from "../utils/ResponseHandler.js";
 
 export class UserController {
+
     constructor(userService) {
         this.userService = userService;
     }
 
+    async createUser(req, res) {
+        try {
+            const {email, name, birth} = req.body;
+
+            const newUser = await this.userService.createUser({
+                email, name, birth,
+            });
+
+            ResponseHandler.success(res, newUser, '사용자가 정상적으로 등록되었습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error);
+        }
+    }
+
 }
 
-export const userController = new UserController(userService);
+export const userController =  new UserController(userService);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -21,6 +21,16 @@ export class UserController {
         }
     }
 
+    async findUserById(req, res) {
+        try {
+            const id = req.params.id;
+
+            const user = await this.userService.findUserById(id);
+            ResponseHandler.success(res, user, '사용자 정보를 성공적으로 가져왔습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error);
+        }
+    }
 }
 
 export const userController =  new UserController(userService);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -15,7 +15,7 @@ export class UserController {
                 email, name, birth,
             });
 
-            ResponseHandler.success(res, newUser, '사용자가 정상적으로 등록되었습니다.');
+            ResponseHandler.success(res, '사용자가 정상적으로 등록되었습니다.', newUser);
         } catch (error) {
             ResponseHandler.error(res, error);
         }
@@ -26,7 +26,7 @@ export class UserController {
             const id = req.params.id;
 
             const user = await this.userService.findUserById(id);
-            ResponseHandler.success(res, user, '사용자 정보를 성공적으로 가져왔습니다.');
+            ResponseHandler.success(res, '사용자 정보를 성공적으로 가져왔습니다.', user);
         } catch (error) {
             ResponseHandler.error(res, error);
         }
@@ -37,7 +37,7 @@ export class UserController {
             const {email} = req.body;
 
             const user = await this.userService.findUserByEmail(email);
-            ResponseHandler.success(res, user, '사용자 정보를 성공적으로 가져왔습니다.');
+            ResponseHandler.success(res, '사용자 정보를 성공적으로 가져왔습니다.', user);
         } catch (error) {
             ResponseHandler.error(res, error);
         }

--- a/src/domain/User.js
+++ b/src/domain/User.js
@@ -33,20 +33,22 @@ export class User {
     }
 
     isValidEmail(email) {
-        if (email === null) {
+        if (!email || email.trim() === '') {
             throw new AppError("이메일은 필수 입력 사항입니다.");
         }
 
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        return emailRegex.test(email);
+        if (!emailRegex.test(email)) {
+            throw new AppError("올바른 이메일 형식이 아닙니다.");
+        }
     }
 
     isValidName(name) {
-        if (name === null || name === undefined) {
+        if (!name || name.trim() === '') {
             throw new AppError("이름은 필수 입력 사항입니다.");
         }
         if (name.length > 10) {
-            throw new AppError("이름은 필수 입력 사항이며 10글자 이내여야 합니다.");
+            throw new AppError("이름은10글자 이내여야 합니다.");
         }
     }
 }

--- a/src/domain/User.js
+++ b/src/domain/User.js
@@ -1,15 +1,11 @@
-import {AppError} from "../utils/AppError.js";
-
 export class User {
     constructor(userData) {
         this.id = userData.id;
         this.email = userData.email;
         this.name = userData.name;
         this.birth = userData.birth;
-        this.createdAt = userData.createdAt;
-        this.updatedAt = userData.updatedAt;
-
-        this.validate();
+        this.createdAt = new Date().toISOString();
+        this.updatedAt = new Date().toISOString();
     }
 
     static fromJSON(userData) {
@@ -25,30 +21,5 @@ export class User {
             createdAt: this.createdAt,
             updatedAt: this.updatedAt,
         };
-    }
-
-    validate() {
-        this.isValidEmail(this.email);
-        this.isValidName(this.name);
-    }
-
-    isValidEmail(email) {
-        if (!email || email.trim() === '') {
-            throw new AppError("이메일은 필수 입력 사항입니다.");
-        }
-
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(email)) {
-            throw new AppError("올바른 이메일 형식이 아닙니다.");
-        }
-    }
-
-    isValidName(name) {
-        if (!name || name.trim() === '') {
-            throw new AppError("이름은 필수 입력 사항입니다.");
-        }
-        if (name.length > 10) {
-            throw new AppError("이름은10글자 이내여야 합니다.");
-        }
     }
 }

--- a/src/domain/User.js
+++ b/src/domain/User.js
@@ -42,7 +42,10 @@ export class User {
     }
 
     isValidName(name) {
-        if (name === null || name.length < 10) {
+        if (name === null || name === undefined) {
+            throw new AppError("이름은 필수 입력 사항입니다.");
+        }
+        if (name.length > 10) {
             throw new AppError("이름은 필수 입력 사항이며 10글자 이내여야 합니다.");
         }
     }

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {AppError} from "../utils/AppError.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -47,6 +48,10 @@ class UserRepository {
     async create(userData) {
         const users = await this.load();
 
+        if (this.isDuplicatedEmail(users, userData.email)) {
+            throw new AppError("이미 가입한 이메일입니다.");
+        }
+
         userData.id = 1;
         if (users.length !== 0) {
             userData.id = Math.max(...users.map(user => user.id)) + 1;
@@ -73,6 +78,12 @@ class UserRepository {
         const users = await this.load();
 
         return users.filter(user => user.email === email);
+    }
+
+    isDuplicatedEmail(users, email) {
+        const result = users.filter(user => user.email === email);
+
+        return result.length !== 0;
     }
 }
 

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -52,6 +52,7 @@ class UserRepository {
             updatedAt: new Date().toISOString(),
         };
 
+        users.push(newUser);
         await this.save(users);
         return newUser;
     }

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -57,4 +57,4 @@ class UserRepository {
     }
 }
 
-export default new UserRepository();
+export const userRepository = new UserRepository();

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -5,7 +5,7 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-class UserRepository{
+class UserRepository {
     constructor() {
         this.dataFilePath = path.join(__dirname, '../../data/users.json');
         this.initialize();
@@ -14,7 +14,7 @@ class UserRepository{
     async initialize() {
         try {
             const dataDir = path.dirname(this.dataFilePath);
-            await fs.mkdir(dataDir, { recursive: true });
+            await fs.mkdir(dataDir, {recursive: true});
 
             try {
                 await fs.access(this.dataFilePath);
@@ -39,9 +39,21 @@ class UserRepository{
     async save(data) {
         try {
             await fs.writeFile(this.dataFilePath, JSON.stringify(data, null, 2));
-        } catch (error){
+        } catch (error) {
             console.error("데이터 저장 실패", error);
         }
+    }
+
+    async create(userData) {
+        const users = await this.load();
+        const newUser = {
+            ...userData,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+        };
+
+        await this.save(users);
+        return newUser;
     }
 }
 

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -62,6 +62,12 @@ class UserRepository {
         await this.save(users);
         return newUser;
     }
+
+    async findUserById(id) {
+        const users = await this.load();
+
+        return users.filter(user => user.id == id);
+    }
 }
 
 export const userRepository = new UserRepository();

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -46,6 +46,12 @@ class UserRepository {
 
     async create(userData) {
         const users = await this.load();
+
+        userData.id = 1;
+        if (users.length !== 0) {
+            userData.id = Math.max(...users.map(user => user.id)) + 1;
+        }
+
         const newUser = {
             ...userData,
             createdAt: new Date().toISOString(),

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -66,7 +66,13 @@ class UserRepository {
     async findUserById(id) {
         const users = await this.load();
 
-        return users.filter(user => user.id == id);
+        return users.filter(user => user.id === Number(id));
+    }
+
+    async findUserByEmail(email) {
+        const users = await this.load();
+
+        return users.filter(user => user.email === email);
     }
 }
 

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -8,4 +8,9 @@ userRouter.post('/users', async (req, res) => {
     await userController.createUser(req, res);
 })
 
+/* 회원 조회 (id) */
+userRouter.get('/user/:id', async (req, res) => {
+    await userController.findUserById(req, res);
+})
+
 export default userRouter;

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -13,4 +13,9 @@ userRouter.get('/user/:id', async (req, res) => {
     await userController.findUserById(req, res);
 })
 
+/* 회원 조회 (email) */
+userRouter.get('/user', async (req, res) => {
+    await userController.findUserByEmail(req, res);
+})
+
 export default userRouter;

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -4,7 +4,7 @@ import {userController} from "../controllers/UserController.js";
 const userRouter = new Router();
 
 /* 회원 등록 */
-userRouter.post('/users', async (req, res) => {
+userRouter.post('/user', async (req, res) => {
     await userController.createUser(req, res);
 })
 

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -3,4 +3,9 @@ import {userController} from "../controllers/UserController.js";
 
 const userRouter = new Router();
 
+/* 회원 등록 */
+userRouter.post('/users', async (req, res) => {
+    await userController.createUser(req, res);
+})
+
 export default userRouter;

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -4,17 +4,17 @@ import {userController} from "../controllers/UserController.js";
 const userRouter = new Router();
 
 /* 회원 등록 */
-userRouter.post('/user', async (req, res) => {
+userRouter.post('/users', async (req, res) => {
     await userController.createUser(req, res);
 })
 
 /* 회원 조회 (id) */
-userRouter.get('/user/:id', async (req, res) => {
+userRouter.get('/users/:id', async (req, res) => {
     await userController.findUserById(req, res);
 })
 
 /* 회원 조회 (email) */
-userRouter.get('/user', async (req, res) => {
+userRouter.get('/users', async (req, res) => {
     await userController.findUserByEmail(req, res);
 })
 

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -21,6 +21,10 @@ export class UserService {
         const savedUser = await this.userRepository.create(newUser);
         return savedUser;
     }
+
+    async findUserById(id) {
+        return await this.userRepository.findUserById(id);
+    }
 }
 
 export const userService = new UserService(userRepository);

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -7,6 +7,10 @@ export class UserService {
         this.userRepository = userRepository;
     }
 
+    async initialize() {
+        await this.userRepository.initialize();
+    }
+
     async createUser(userData) {
         const newUser = new User({
             email: userData.email,
@@ -14,7 +18,8 @@ export class UserService {
             birth: userData.birth,
         })
 
-        return await this.userRepository.save(newUser);
+        const savedUser = await this.userRepository.create(newUser);
+        return savedUser;
     }
 }
 

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,14 +1,12 @@
 import {userRepository} from "../repositories/UserRepository.js";
 
-export class UserService {
-    constructor(userRepository) {
-        this.userRepository = userRepository;
-    }
+class UserService {
 
-    async initialize() {
-        await this.userRepository.initialize();
-    }
+    async createUser(userData) {
+        const newUser = await userRepository.createUser(userData);
 
+        return newUser;
+    }
 }
 
-export const userService = new UserService(userRepository);
+export default new UserService();

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,12 +1,21 @@
 import {userRepository} from "../repositories/UserRepository.js";
+import {User} from "../domain/User.js";
 
-class UserService {
+export class UserService {
+
+    constructor(userRepository) {
+        this.userRepository = userRepository;
+    }
 
     async createUser(userData) {
-        const newUser = await userRepository.createUser(userData);
+        const newUser = new User({
+            email: userData.email,
+            name: userData.name,
+            birth: userData.birth,
+        })
 
-        return newUser;
+        return await this.userRepository.save(newUser);
     }
 }
 
-export default new UserService();
+export const userService = new UserService(userRepository);

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -25,6 +25,10 @@ export class UserService {
     async findUserById(id) {
         return await this.userRepository.findUserById(id);
     }
+
+    async findUserByEmail(email) {
+        return await this.userRepository.findUserByEmail(email);
+    }
 }
 
 export const userService = new UserService(userRepository);

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -12,11 +12,7 @@ export class UserService {
     }
 
     async createUser(userData) {
-        const newUser = new User({
-            email: userData.email,
-            name: userData.name,
-            birth: userData.birth,
-        })
+        const newUser = new User({...userData});
 
         const savedUser = await this.userRepository.create(newUser);
         return savedUser;

--- a/src/utils/ResponseHandler.js
+++ b/src/utils/ResponseHandler.js
@@ -1,5 +1,5 @@
 export class ResponseHandler {
-    static success(res, data = null, message) {
+    static success(res, message, data = null) {
         res.end(JSON.stringify({
             status: 'success', message: message, data
         }));

--- a/src/utils/Routes.js
+++ b/src/utils/Routes.js
@@ -29,6 +29,15 @@ export class Router {
         return this;
     }
 
+    use(router) {
+        Object.keys(router.routes).forEach(method => {
+            Object.keys(router.routes[method]).forEach(path => {
+                this.routes[method][path] = router.routes[method][path];
+            });
+        })
+        return this;
+    }
+
     async handleRequest(req, res) {
         try {
             const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
@@ -44,13 +53,12 @@ export class Router {
 
             if (handler) {
                 req.params = params;
-
                 await handler(req, res);
             } else {
                 ResponseHandler.error(res, '요청한 리소스를 찾을 수 없습니다.');
             }
         } catch (error) {
-            ResponseHandler.error(res, '서버 내류 오류가 발생했습니다.');
+            ResponseHandler.error(res, '서버 내부 오류가 발생했습니다.');
         }
     }
 
@@ -71,9 +79,9 @@ export class Router {
                 }
             });
 
-            req.on(('error', (error) => {
+            req.on('error', (error) => {
                 reject(new AppError(error.message, 400));
-            }));
+            });
         });
     }
 
@@ -97,7 +105,6 @@ export class Router {
                 };
             }
         }
-
         return {handler: null, params: {}};
     }
 


### PR DESCRIPTION
### 1. 신규 유저 등록 API
- 신규 유저 등록시 이메일 중복 검사 후 동일한 이메일이 있는 경우 반려
- 신규 유저 등록시 이메일 및 이름에 대한 유효성 검사
- 유저의 ID는 `auto_increment` 형식으로 1씩 증가하며 저장

### 2. 유저 정보 조회 API
- ID 기준으로 유저 정보 조회 API
- Email 기준으로 유저 정보 조회 API
- 조회시 기존 데이터들을 모두 가져와서 `.filter()` 를 활용하여 일치하는 데이터 반환