### PR TITLE
[feat/2] 유저 정보 수정 및 삭제 API 구현

### DIFF
--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -47,6 +47,17 @@ export class UserController {
         }
     }
 
+    async update(req, res) {
+        try {
+            const {email, name, birth} = req.body;
+
+            const updatedUser = await this.userService.update({email, name, birth});
+            ResponseHandler.success(res, updatedUser, '사용자 정보를 성공적으로 수정했습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error.message, error);
+        }
+    }
+
     validateEmail(email) {
         if (!email || email.trim() === '') {
             throw new ValidationError("이메일은 필수 입력 사항입니다.");

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -58,6 +58,17 @@ export class UserController {
         }
     }
 
+    async delete(req, res) {
+        try {
+            const id = req.params.id;
+
+            await this.userService.delete(id);
+            ResponseHandler.success(res, null, '사용자를 성공적으로 삭제했습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error.message, error);
+        }
+    }
+
     validateEmail(email) {
         if (!email || email.trim() === '') {
             throw new ValidationError("이메일은 필수 입력 사항입니다.");
@@ -75,18 +86,6 @@ export class UserController {
         }
         if (name.length > 10) {
             throw new ValidationError("이름은10글자 이내여야 합니다.");
-        }
-    }
-
-
-    async delete(req, res) {
-        try {
-            const id = req.params.id;
-
-            await this.userService.delete(id);
-            ResponseHandler.success(res, null, '사용자를 성공적으로 삭제했습니다.');
-        } catch (error) {
-            ResponseHandler.error(res, error.message, error);
         }
     }
 }

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -78,6 +78,17 @@ export class UserController {
         }
     }
 
+
+    async delete(req, res) {
+        try {
+            const id = req.params.id;
+
+            await this.userService.delete(id);
+            ResponseHandler.success(res, null, '사용자를 성공적으로 삭제했습니다.');
+        } catch (error) {
+            ResponseHandler.error(res, error.message, error);
+        }
+    }
 }
 
 export const userController = new UserController(userService);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -19,7 +19,7 @@ export class UserController {
 
             ResponseHandler.success(res, '사용자가 정상적으로 등록되었습니다.', newUser);
         } catch (error) {
-            ResponseHandler.error(res, error);
+            ResponseHandler.error(res, error.message, error);
         }
     }
 
@@ -30,7 +30,7 @@ export class UserController {
             const user = await this.userService.findUserById(id);
             ResponseHandler.success(res, '사용자 정보를 성공적으로 가져왔습니다.', user);
         } catch (error) {
-            ResponseHandler.error(res, error);
+            ResponseHandler.error(res, error.message, error);
         }
     }
 
@@ -43,7 +43,7 @@ export class UserController {
             const user = await this.userService.findUserByEmail(email);
             ResponseHandler.success(res, '사용자 정보를 성공적으로 가져왔습니다.', user);
         } catch (error) {
-            ResponseHandler.error(res, error);
+            ResponseHandler.error(res, error.message, error);
         }
     }
 

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import {fileURLToPath} from 'url';
-import {AppError} from "../utils/AppError.js";
+import {AppError, NotFoundError} from "../utils/AppError.js";
 import {User} from "../domain/User.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -83,7 +83,7 @@ class UserRepository {
         const updateUser = users.find(user => user.email === updateUserData.email);
 
         if (!updateUser) {
-            throw new AppError("해당 이메일을 가진 사용자가 없습니다.");
+            throw new NotFoundError("해당 이메일을 가진 사용자가 없습니다.");
         }
 
         updateUser.name = updateUserData.name;

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import {fileURLToPath} from 'url';
 import {AppError} from "../utils/AppError.js";
+import {User} from "../domain/User.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -57,11 +58,7 @@ class UserRepository {
             userData.id = Math.max(...users.map(user => user.id)) + 1;
         }
 
-        const newUser = {
-            ...userData,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-        };
+        const newUser = new User({...userData});
 
         users.push(newUser);
         await this.save(users);

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -48,7 +48,7 @@ class UserRepository {
     async create(userData) {
         const users = await this.load();
 
-        if (this.isDuplicatedEmail(users, userData.email)) {
+        if (this.isExistedEmail(users, userData.email)) {
             throw new AppError("이미 가입한 이메일입니다.");
         }
 
@@ -97,7 +97,14 @@ class UserRepository {
         return updateUser;
     }
 
-    isDuplicatedEmail(users, email) {
+    async delete(id) {
+        const users = await this.load();
+        const newUsers = users.filter(user => user.id !== Number(id));
+
+        await this.save(newUsers);
+    }
+
+    isExistedEmail(users, email) {
         const result = users.filter(user => user.email === email);
 
         return result.length !== 0;

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -80,6 +80,23 @@ class UserRepository {
         return users.filter(user => user.email === email);
     }
 
+    async update(updateUserData) {
+        const users = await this.load();
+
+        const updateUser = users.find(user => user.email === updateUserData.email);
+
+        if (!updateUser) {
+            throw new AppError("해당 이메일을 가진 사용자가 없습니다.");
+        }
+
+        updateUser.name = updateUserData.name;
+        updateUser.birth = updateUserData.birth;
+        updateUser.updatedAt = new Date().toISOString();
+
+        await this.save(users);
+        return updateUser;
+    }
+
     isDuplicatedEmail(users, email) {
         const result = users.filter(user => user.email === email);
 

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -19,12 +19,12 @@ userRouter.get('/users', async (req, res) => {
 })
 
 /* 회원 정보 수정 */
-userRouter.put('/user', async (req, res) => {
+userRouter.put('/users', async (req, res) => {
     await userController.update(req, res);
 })
 
 /* 회원 정보 삭제 */
-userRouter.delete('/user/:id', async (req, res) => {
+userRouter.delete('/users/:id', async (req, res) => {
     await userController.delete(req, res);
 })
 

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -23,4 +23,9 @@ userRouter.put('/user', async (req, res) => {
     await userController.update(req, res);
 })
 
+/* 회원 정보 삭제 */
+userRouter.delete('/user/:id', async (req, res) => {
+    await userController.delete(req, res);
+})
+
 export default userRouter;

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -18,4 +18,9 @@ userRouter.get('/users', async (req, res) => {
     await userController.findUserByEmail(req, res);
 })
 
+/* 회원 정보 수정 */
+userRouter.put('/user', async (req, res) => {
+    await userController.update(req, res);
+})
+
 export default userRouter;

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -25,6 +25,10 @@ export class UserService {
     async findUserByEmail(email) {
         return await this.userRepository.findUserByEmail(email);
     }
+
+    async update(updateUserData) {
+        return await this.userRepository.update(updateUserData);
+    }
 }
 
 export const userService = new UserService(userRepository);

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -29,6 +29,10 @@ export class UserService {
     async update(updateUserData) {
         return await this.userRepository.update(updateUserData);
     }
+
+    async delete(id) {
+        return await this.userRepository.delete(id);
+    }
 }
 
 export const userService = new UserService(userRepository);

--- a/src/utils/ResponseHandler.js
+++ b/src/utils/ResponseHandler.js
@@ -7,7 +7,7 @@ export class ResponseHandler {
 
     static error(res, message, error = null) {
         res.end(JSON.stringify({
-            status: 'error', message: message,
+            status: 'error', message: message, error
         }));
     }
 }


### PR DESCRIPTION
### 1. 유저 정보 수정 API
- 수정하려는 대상이 있는지 유효성 검사 (이메일 검사)
- 수정 완료시 `updatedAt` 변수명 수정 시간으로 변경
- 동기함수인 `find()` 를 사용하여 이메일이 같은 유저 정보를 가져옴

### 2. 유저 정보 삭제
- `delete` 로 객체의 프로퍼티를 제거해보려 했지만, 제거 후 {} 빈 객체만 남는 현상 발견
- `filter()`를 활용해 제거하려는 객체를 제외한 새로운 `users` 를 users.json에 저장하는 방식으로 삭제 구현